### PR TITLE
Fix ORM setup portability

### DIFF
--- a/tests/utest/cache/CacheTestCase.php
+++ b/tests/utest/cache/CacheTestCase.php
@@ -37,14 +37,20 @@ abstract class CacheTestCase extends TestCase
     }
 
     /**
-     * @param $tableName
-     * @param IServer $server
+     * Пересоздает таблицу кеша в базе данных
+     * @param string $tableName имя таблицы кеша
+     * @param IServer $server сервер базы данных, в которой будет создана таблица
      */
     protected function setupCacheDatabase($tableName, $server = null)
     {
-        $connection = is_null($server) ? $this->getDefaultDbServer()->getConnection() : $server->getConnection();
+        $connection = is_null($server) ? $this
+            ->getDefaultDbServer()
+            ->getConnection() : $server->getConnection();
 
-        if ($connection->getSchemaManager()->tablesExist($tableName)) {
+        if ($connection
+            ->getSchemaManager()
+            ->tablesExist($tableName)
+        ) {
             $connection
                 ->getSchemaManager()
                 ->dropTable($tableName);

--- a/tests/utest/cache/unit/engine/DbTest.php
+++ b/tests/utest/cache/unit/engine/DbTest.php
@@ -21,27 +21,22 @@ class DbTest extends CacheTestCase
     /**
      * @var Db $storage
      */
-    private $storage;
+    protected $defaultStorage;
 
-    private $tableName = 'test_cache_storage';
+    protected $tableName = 'test_cache_storage';
 
     protected function setUpFixtures()
     {
         $server = $this->getDefaultDbServer();
-        $options = [
-            'table'    => [
-                'tableName'        => $this->tableName,
-                'keyColumnName'    => 'key',
-                'valueColumnName'  => 'cacheValue',
-                'expireColumnName' => 'cacheExpiration'
-            ],
-            'serverId' => $server->getId()
-        ];
 
         $this->setupCacheDatabase($this->tableName, $server);
 
-        $this->storage = new Db($options);
-        $this->resolveOptionalDependencies($this->storage);
+        $options = [
+            'table'    => $this->tableConfig($this->tableName),
+            'serverId' => $server->getId()
+        ];
+        $this->defaultStorage = new Db($options);
+        $this->resolveOptionalDependencies($this->defaultStorage);
     }
 
     protected function tearDownFixtures()
@@ -53,102 +48,52 @@ class DbTest extends CacheTestCase
             ->dropTable($this->tableName);
     }
 
-    public function testGetServer()
+    /**
+     * Конфигурация таблицы БД для кеша
+     * @param string $tableName
+     *
+     * @return array
+     */
+    protected function tableConfig($tableName)
     {
-        $this->markTestIncomplete();
-
-        $defaultServer = $this
-            ->getDbCluster()
-            ->getMaster();
-        $nonDefaultServer = $this
-            ->getMysqlServer()
-            ->getId() == $defaultServer->getId()
-            ? $this->getSqliteServer()
-            : $this->getMysqlServer();
-
-        $this->setupCacheDatabase($this->tableName, $nonDefaultServer);
-
-        $tableConfig = [
-            'tableName'        => $this->tableName,
+        return [
+            'tableName'        => $tableName,
             'keyColumnName'    => 'key',
             'valueColumnName'  => 'cacheValue',
             'expireColumnName' => 'cacheExpiration'
         ];
-        $dbMysql = new Db([
-            'table'    => $tableConfig,
-            'serverId' => $this
-                ->getMysqlServer()
-                ->getId()
-        ]);
-        $this->resolveOptionalDependencies($dbMysql);
-        $dbMysql->set('first', 'mysqlMaster');
-
-        $dbSqlite = new Db([
-            'table'    => $tableConfig,
-            'serverId' => $this
-                ->getSqliteServer()
-                ->getId()
-        ]);
-        $this->resolveOptionalDependencies($dbSqlite);
-        $dbSqlite->set('first', 'sqliteMaster');
-
-        $dbDefault = new Db([
-            'table' => $tableConfig,
-        ]);
-        $this->resolveOptionalDependencies($dbDefault);
-        $dbDefault->set('second', $defaultServer->getId());
-
-        $recordsNonDefault = $nonDefaultServer
-            ->select(['key', 'cacheValue'])
-            ->from($this->tableName)
-            ->execute()
-            ->fetchAll();
-
-        $this->assertEquals(
-            [
-                ['key' => 'first', 'cacheValue' => $nonDefaultServer->getId()]
-            ],
-            $recordsNonDefault
-        );
-
-        $recordsDefault = $defaultServer
-            ->select(['key', 'cacheValue'])
-            ->from($this->tableName)
-            ->execute()
-            ->fetchAll();
-        $this->assertEquals(
-            [
-                ['key' => 'first', 'cacheValue' => $defaultServer->getId()],
-                ['key' => 'second', 'cacheValue' => $defaultServer->getId()]
-            ],
-            $recordsDefault
-        );
-
-        $nonDefaultServer
-            ->getConnection()
-            ->getSchemaManager()
-            ->dropTable($this->tableName);
     }
 
     public function testStorage()
     {
-        $this->assertFalse($this->storage->get('testKey'), 'Значение уже есть в кеше');
+        $this->assertFalse($this->defaultStorage->get('testKey'), 'Значение уже есть в кеше');
 
-        $this->assertTrue($this->storage->set('testKey', 'testValue', 3), 'Не удалось сохранить значение в кеш');
-        $this->assertEquals('testValue', $this->storage->get('testKey'), 'В кеше хранится неверное значение');
+        $this->assertTrue($this->defaultStorage->set('testKey', 'testValue', 3), 'Не удалось сохранить значение в кеш');
+        $this->assertEquals('testValue', $this->defaultStorage->get('testKey'), 'В кеше хранится неверное значение');
 
         $this->assertTrue(
-            $this->storage->set('testKey', 'newTestValue', 3),
+            $this->defaultStorage->set('testKey', 'newTestValue', 3),
             'Не удалось переопределить значение в кеше'
         );
         $this->assertFalse(
-            $this->storage->add('testKey', 'newNewTestValue', 3),
+            $this->defaultStorage->add('testKey', 'newNewTestValue', 3),
             'Удалось переопределить значение в кеше'
         );
-        $this->assertEquals('newTestValue', $this->storage->get('testKey'), 'В кеш добавилось неверное значение');
+        $this->assertEquals(
+            'newTestValue',
+            $this->defaultStorage->get('testKey'),
+            'В кеш добавилось неверное значение'
+        );
 
-        $this->assertTrue($this->storage->add('newTestKey', 'testValue', 3), 'Не удалось добавить значение в кеш');
-        $this->assertEquals('testValue', $this->storage->get('newTestKey'), 'В кеш добавилось неверное значение');
+        $this->assertTrue(
+            $this->defaultStorage->add('newTestKey', 'testValue', 3),
+            'Не удалось добавить значение в кеш'
+        );
+        $this->assertEquals(
+            'testValue',
+            $this->defaultStorage->get('newTestKey'),
+            'В кеш добавилось неверное значение'
+        );
 
         $update = $this
             ->getDefaultDbServer()
@@ -162,15 +107,15 @@ class DbTest extends CacheTestCase
             ->bindString(':id', 'testKey');
         $update->execute();
 
-        $this->assertFalse($this->storage->get('testKey'), 'Время кеша должно было истечь');
+        $this->assertFalse($this->defaultStorage->get('testKey'), 'Время кеша должно было истечь');
 
-        $this->storage->set('testKey', 'newTestValue', 3);
-        $this->assertTrue($this->storage->remove('testKey'), 'Не удалось удалить значение из кеша');
-        $this->assertFalse($this->storage->get('testKey'), 'Значение в кеше существует после удаления');
+        $this->defaultStorage->set('testKey', 'newTestValue', 3);
+        $this->assertTrue($this->defaultStorage->remove('testKey'), 'Не удалось удалить значение из кеша');
+        $this->assertFalse($this->defaultStorage->get('testKey'), 'Значение в кеше существует после удаления');
 
-        $this->storage->set('testKey1', 'testValue1', 3);
-        $this->storage->set('testKey2', 'testValue2');
-        $this->storage->set('testKey3', 'testValue3', 3);
+        $this->defaultStorage->set('testKey1', 'testValue1', 3);
+        $this->defaultStorage->set('testKey2', 'testValue2');
+        $this->defaultStorage->set('testKey3', 'testValue3', 3);
 
         $update = $this
             ->getDefaultDbServer()
@@ -192,14 +137,14 @@ class DbTest extends CacheTestCase
         ];
         $this->assertEquals(
             $expectedResult,
-            $this->storage->getList(['testKey1', 'testKey2', 'testKey3', 'testKey4']),
+            $this->defaultStorage->getList(['testKey1', 'testKey2', 'testKey3', 'testKey4']),
             'Неверное значение для массива ключей'
         );
 
-        $this->assertTrue($this->storage->clear(), 'Не удалось очистить кеш');
+        $this->assertTrue($this->defaultStorage->clear(), 'Не удалось очистить кеш');
         $this->assertEquals(
             ['testKey1' => false, 'testKey2' => false],
-            $this->storage->getList(['testKey1', 'testKey2']),
+            $this->defaultStorage->getList(['testKey1', 'testKey2']),
             'Неверное значение для массива ключей после очистки кеша'
         );
     }

--- a/tests/utest/cache/unit/engine/MultiDbTest.php
+++ b/tests/utest/cache/unit/engine/MultiDbTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * UMI.Framework (http://umi-framework.ru/)
+ *
+ * @link      http://github.com/Umisoft/framework for the canonical source repository
+ * @copyright Copyright (c) 2007-2013 Umisoft ltd. (http://umisoft.ru/)
+ * @license   http://umi-framework.ru/license/bsd-3 BSD-3 License
+ */
+
+namespace utest\cache\unit\engine;
+
+use Doctrine\DBAL\Types\Type;
+use umi\cache\engine\Db;
+use umi\dbal\cluster\server\IServer;
+
+/**
+ * Тесты, предполагающие наличие в окружении более, чем одного сервера БД
+ */
+class MultiDbTest extends DbTest
+{
+    /**
+     * @var IServer $nonDefaultServer
+     */
+    private $nonDefaultServer;
+    /**
+     * @var Db $mysqlStorage
+     */
+    private $mysqlStorage;
+    /**
+     * @var Db $sqliteStorage
+     */
+    private $sqliteStorage;
+
+    protected function setUpFixtures()
+    {
+        $defaultServer = $this->getDefaultDbServer();
+        $mysqlServer = $this->getMysqlServer();
+        $sqliteServer = $this->getSqliteServer();
+
+        $this->nonDefaultServer = $mysqlServer === $defaultServer ? $sqliteServer : $mysqlServer;
+
+        $this->setupCacheDatabase($this->tableName, $this->getDefaultDbServer());
+        $this->setupCacheDatabase($this->tableName, $this->nonDefaultServer);
+
+        $options = [
+            'table'=>$this->tableConfig($this->tableName),
+            'serverId' => $mysqlServer->getId()
+        ];
+        $this->mysqlStorage = new Db($options);
+        $this->resolveOptionalDependencies($this->mysqlStorage);
+
+        $options = [
+            'table'=>$this->tableConfig($this->tableName),
+            'serverId' => $sqliteServer->getId()
+        ];
+        $this->sqliteStorage = new Db($options);
+        $this->resolveOptionalDependencies($this->sqliteStorage);
+
+        $options = [
+            'table'=>$this->tableConfig($this->tableName),
+        ];
+        $this->defaultStorage = new Db($options);
+        $this->resolveOptionalDependencies($this->defaultStorage);
+
+    }
+
+    protected function tearDownFixtures()
+    {
+        $this
+            ->getDefaultDbServer()
+            ->getConnection()
+            ->getSchemaManager()
+            ->dropTable($this->tableName);
+        $this
+            ->nonDefaultServer
+            ->getConnection()
+            ->getSchemaManager()
+            ->dropTable($this->tableName);
+    }
+
+    public function testGetServer()
+    {
+        $this->mysqlStorage->set('first', $this->getMysqlServer()->getId());
+        $this->sqliteStorage->set('first', $this->getSqliteServer()->getId());
+        $this->defaultStorage->set('second', $this->getDefaultDbServer()->getId());
+
+        $recordsNonDefault = $this->nonDefaultServer
+            ->select(['key', 'cacheValue'])
+            ->from($this->tableName)
+            ->execute()
+            ->fetchAll();
+
+        $this->assertEquals(
+            [
+                ['key' => 'first', 'cacheValue' => $this->nonDefaultServer->getId()]
+            ],
+            $recordsNonDefault,
+            'В сервере, не назначенном по умолчанию, должна быть только одна запись'
+        );
+
+        $recordsDefault = $this->getDefaultDbServer()
+            ->select(['key', 'cacheValue'])
+            ->from($this->tableName)
+            ->execute()
+            ->fetchAll();
+
+        $this->assertEquals(
+            [
+                ['key' => 'first', 'cacheValue' => $this->getDefaultDbServer()->getId()],
+                ['key' => 'second', 'cacheValue' => $this->getDefaultDbServer()->getId()]
+            ],
+            $recordsDefault,
+            'В сервере по умолчанию должны быть 2 записи:'
+            . ' одна, сохраненная «наугад» и одна явно сохраненная в сервер по умолчанию'
+        );
+    }
+}

--- a/tests/utest/orm/mock/collections/setup/blogs_blog.setup.php
+++ b/tests/utest/orm/mock/collections/setup/blogs_blog.setup.php
@@ -29,7 +29,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::GUID)
         ->setNotnull(false);
     $table
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
     $table
         ->addColumn('version', Type::INTEGER)
@@ -40,10 +40,10 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('pid', Type::INTEGER)
         ->setNotnull(false);
     $table
-        ->addColumn('mpath', Type::TEXT)
+        ->addColumn('mpath', Type::STRING)
         ->setNotnull(false);
     $table
-        ->addColumn('uri', Type::TEXT)
+        ->addColumn('uri', Type::STRING)
         ->setNotnull(false);
     $table
         ->addColumn('slug', Type::STRING)

--- a/tests/utest/orm/mock/collections/setup/blogs_blog_subscribers.setup.php
+++ b/tests/utest/orm/mock/collections/setup/blogs_blog_subscribers.setup.php
@@ -29,7 +29,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::GUID)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
     $tableScheme
         ->addColumn('version', Type::INTEGER)

--- a/tests/utest/orm/mock/collections/setup/blogs_post.setup.php
+++ b/tests/utest/orm/mock/collections/setup/blogs_post.setup.php
@@ -29,7 +29,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
     $tableScheme
         ->addColumn(
@@ -43,10 +43,10 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('pid', Type::INTEGER)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('mpath', Type::TEXT)
+        ->addColumn('mpath', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('uri', Type::TEXT)
+        ->addColumn('uri', Type::STRING)
         ->setNotnull(false);
     $tableScheme
         ->addColumn('slug', Type::STRING)

--- a/tests/utest/orm/mock/collections/setup/guides_city.setup.php
+++ b/tests/utest/orm/mock/collections/setup/guides_city.setup.php
@@ -29,7 +29,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
     $tableScheme
         ->addColumn(

--- a/tests/utest/orm/mock/collections/setup/guides_country.setup.php
+++ b/tests/utest/orm/mock/collections/setup/guides_country.setup.php
@@ -22,7 +22,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
     $tableScheme
         ->addColumn(

--- a/tests/utest/orm/mock/collections/setup/system_hierarchy.setup.php
+++ b/tests/utest/orm/mock/collections/setup/system_hierarchy.setup.php
@@ -29,7 +29,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
 
     $tableScheme
@@ -44,10 +44,10 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('pid', Type::INTEGER)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('mpath', Type::TEXT)
+        ->addColumn('mpath', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('uri', Type::TEXT)
+        ->addColumn('uri', Type::STRING)
         ->setNotnull(false);
     $tableScheme
         ->addColumn('slug', Type::STRING)

--- a/tests/utest/orm/mock/collections/setup/system_menu.setup.php
+++ b/tests/utest/orm/mock/collections/setup/system_menu.setup.php
@@ -29,7 +29,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
 
     $tableScheme
@@ -44,10 +44,10 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('pid', Type::INTEGER)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('mpath', Type::TEXT)
+        ->addColumn('mpath', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('uri', Type::TEXT)
+        ->addColumn('uri', Type::STRING)
         ->setNotnull(false);
     $tableScheme
         ->addColumn('slug', Type::STRING)

--- a/tests/utest/orm/mock/collections/setup/users_group.setup.php
+++ b/tests/utest/orm/mock/collections/setup/users_group.setup.php
@@ -22,7 +22,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
 
     $tableScheme

--- a/tests/utest/orm/mock/collections/setup/users_profile.setup.php
+++ b/tests/utest/orm/mock/collections/setup/users_profile.setup.php
@@ -29,7 +29,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
 
     $tableScheme

--- a/tests/utest/orm/mock/collections/setup/users_user.setup.php
+++ b/tests/utest/orm/mock/collections/setup/users_user.setup.php
@@ -29,7 +29,7 @@ return function (ICollectionDataSource $dataSource) {
         ->addColumn('guid', Type::STRING)
         ->setNotnull(false);
     $tableScheme
-        ->addColumn('type', Type::TEXT)
+        ->addColumn('type', Type::STRING)
         ->setNotnull(false);
 
     $tableScheme


### PR DESCRIPTION
Mysql tables setup had [require sized indexes](http://stackoverflow.com/questions/1827063/mysql-error-key-specification-without-a-key-length) on `TEXT` fields. 
All indexed `TEXT` fields replaced with `VARCHAR`
